### PR TITLE
fix: reverse any vs all logic of Sentinel-2 pixel fill value masking

### DIFF
--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -1,3 +1,15 @@
+## LaSRC Version 3.5.2 Release Notes
+Release Date: March, 2025
+
+This release of the LaSRC code has been modified by the NASA-IMPACT team as part of
+maintenance for the HLS project.
+
+### Fixed
+
+- Support Sentinel-2C and -2D by updating hard coded platform values
+- Include `PROC_ALL_BANDS` definition
+- Mask a pixel if _any_ band has invalid data [#17](https://github.com/NASA-IMPACT/espa-surface-reflectance/pull/17)
+
 ## LaSRC Version 3.5.1 Release Notes
 Release Date: TBD 2023
 

--- a/lasrc/c_version/scripts/do_lasrc_sentinel.py
+++ b/lasrc/c_version/scripts/do_lasrc_sentinel.py
@@ -152,7 +152,7 @@ class SurfaceReflectance():
         # file should be used for input.
         # Example: S2A_MSI_L1C_T10TFR_20180816_20180903.xml uses the
         # VJ[12]04ANC.A2018228.001.*.h5 HDF5 file or VNP04ANC.A2018228.001.*.h5.
-        s2_prefixes_collection = ['S2A', 'S2B', 'S2C']
+        s2_prefixes_collection = ['S2A', 'S2B', 'S2C', 'S2D']
         if base_xmlfile[0:3] in s2_prefixes_collection:
             # Collection naming convention. Pull the year, month, day from the
             # XML filename. It should be the 4th group, separated by

--- a/lasrc/c_version/src/common.h
+++ b/lasrc/c_version/src/common.h
@@ -14,7 +14,7 @@ typedef char byte;
 #endif
 
 /* Surface reflectance version */
-#define SR_VERSION "3.5.1 (Collection 2)"
+#define SR_VERSION "3.5.2 (Collection 2)"
 
 /* Define the default aerosol and EPS value */
 #define DEFAULT_AERO 0.05

--- a/lasrc/c_version/src/compute_sentinel_refl.c
+++ b/lasrc/c_version/src/compute_sentinel_refl.c
@@ -633,19 +633,33 @@ int compute_sentinel_sr_refl
     printf ("Performing atmospheric corrections for each Sentinel reflectance "
         "band ... %s", ctime(&mytime)); fflush(stdout);
 
-    /* Flag fill pixels as any pixel with all bands containing fill values.
-       This used to be flag as fill if any pixel is fill, but often the S2
-       values for non-visible bands are a value of 0. */
+    /*
+     * Flag fill pixels as any pixel with any bands containing fill values.
+     *
+     * In `eros-collection2-3.5.1` version this had been configured to flag pixels as valid if ANY band
+     * contained a valid value ("often the S2 values for non-visible bands are a value of 0.")
+     *
+     * This had caused issues with spurious, incorrect surface reflectance values in images because the "0"
+     * data value had been atmospherically corrected.
+     *
+     * As of Sentinel-2 Baseline 4.00 (~Jan, 2022) the L1C data contain an offset of 1_000, so we can now
+     * reliably consider "0" as the masked "fill value".
+     *
+     * This logic has been updated as part of the NASA-IMPACT fork of `eros-collection2-3.5.1` to mask a pixel
+     * if ANY band has a fill data value. This is important as the sensor detectors do not all begin at the
+     * same positions, so we do not want to atmospherically correct fill pixel values. This should fix issues
+     * at the edge of Sentinel-2 granules.
+    */
     for (i = 0; i < npixels; i++)
     {
-        /* Initialize to true and break out if any band is not fill */
-        is_fill = true;
+        /* Initialize to false and break out if any band is fill */
+        is_fill = false;
         for (ib = 0; ib <= SRS_BAND12; ib++)
         {
-            if (toaband[ib][i] != bmeta[ib].fill_value)
+            if (toaband[ib][i] == bmeta[ib].fill_value)
             {
                 /* No need to look any further */
-                is_fill = false;
+                is_fill = true;
                 break;
             }
         }  /* end for ib */

--- a/scripts/surface_reflectance.py
+++ b/scripts/surface_reflectance.py
@@ -97,7 +97,7 @@ def parse_cmd_line():
 def get_science_application_name(satellite_sensor_code):
     '''Returns name of executable that needs to be called'''
 
-    s2_prefixes_collection = ['S2A_', 'S2B_', 'S2C_']
+    s2_prefixes_collection = ['S2A_', 'S2B_', 'S2C_', 'S2D_']
     l89_prefixes_collection = ['LC08', 'LO08', 'LT08', 'LC09', 'LO09', 'LT09']
     other_prefixes_collection = ['LT04', 'LT05', 'LE07']
 


### PR DESCRIPTION
## Description

This PR addresses a few issues that are ultimately all caused by the same masking logic based on fill values. This issue indirectly impacts or causes issues including,

1. Incorrect values at the edge of granules (see screenshot [1])
2. Issues applying the Sentinel-2 quality mask band-by-band
    * See known issue "Failure in applying Sentinel-2 image quality mask" https://lpdaac.usgs.gov/products/hlsl30v002/
    * See PR, https://github.com/NASA-IMPACT/hls-sentinel/pull/167
3. Issues with overlapping "twin granule" acquisitions
    * See issue, https://github.com/NASA-IMPACT/hls-sentinel/issues/164

[1] ![Bad values at edge of granules](https://github.com/user-attachments/assets/33c7c346-3a83-4c55-a690-7b0b76dd0981)


## How I did it

I reversed the fill value logic so that a pixel is considered invalid if ANY band is a fill value.

## How you can test it

As there is no testing framework in this code, testing will require running granules through the atmospheric correct pipeline. I've done some testing of this in our UAT environment by including this PR in a change in [hls-sentinel](https://github.com/NASA-IMPACT/hls-sentinel):

This GIF record shows a sequence of the same image using the same contrast stretch for the green band (B03). I gave the layers names on the left hand side, but to emphasize the first shows,
1. Production (no QA band applied, no LaSRC fix)
2. UAT version 1 (QA band applied, no LaSRC fix)
2. UAT version 2 (QA band applied AND LaSRC fix)

You can see at the top of the first image the lost/degraded packet issue. In the second image these pixels are fixed, but there remains the issue along the border of the granule where the LaSRC issue occurs. In the 3rd image both of these issues are fixed

![2025-03-06 13 20 00](https://github.com/user-attachments/assets/e3e29112-95b6-4875-ba8c-bc2b2f180de6)