### PR TITLE
chore: update semantic version to include maintainer information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+with an additional version indicator for modifications of this fork.
+
+## [Unreleased]
+
+### Added <!-- New features -->
+
+-
+
+### Changed <!-- Changes in existing functionality -->
+
+-
+
+### Deprecated <!-- Soon-to-be removed features -->
+
+-
+
+### Removed <!-- Now removed features -->
+
+-
+
+### Fixed <!-- Any bug fixes -->
+
+-
+
+### Security <!-- In case of vulnerabilities -->
+
+-
+
+## [v3.5.1.0]
+
+Release Date: March, 2025
+
+This release of the LaSRC code has been modified by the NASA-IMPACT team as part of
+maintenance for the HLS project based off of the USGS's version `v3.5.1`.
+We are indicating this change by appending a "maintainer version" to the version tag
+(`[major].[minor].[patch].[maintainer]`). This is done to prevent potential confusion
+with releases from the upstream.
+
+### Fixed
+
+- Support Sentinel-2C and -2D by updating hard coded platform values
+- Include `PROC_ALL_BANDS` definition
+- Mask a pixel if _any_ band has invalid data [#17](https://github.com/NASA-IMPACT/espa-surface-reflectance/pull/17)
+
+
+[Unreleased]: https://github.com/NASA-IMPACT/espa-surface-reflectance/tree/v3.5.1.0...HEAD
+[v3.5.1.0]: https://github.com/NASA-IMPACT/espa-surface-reflectance/tree/v3.5.1.0

--- a/lasrc/README.md
+++ b/lasrc/README.md
@@ -1,8 +1,12 @@
-## LaSRC Version 3.5.2 Release Notes
+## LaSRC Version 3.5.1.0 Release Notes
+
 Release Date: March, 2025
 
 This release of the LaSRC code has been modified by the NASA-IMPACT team as part of
-maintenance for the HLS project.
+maintenance for the HLS project based off of the USGS's version `v3.5.1`.
+We are indicating this change by appending a "maintainer version" to the version tag
+(`[major].[minor].[patch].[maintainer]`). This is done to prevent potential confusion
+with releases from the upstream.
 
 ### Fixed
 

--- a/lasrc/c_version/src/common.h
+++ b/lasrc/c_version/src/common.h
@@ -14,7 +14,7 @@ typedef char byte;
 #endif
 
 /* Surface reflectance version */
-#define SR_VERSION "3.5.2 (Collection 2)"
+#define SR_VERSION "3.5.1.0 (Collection 2)"
 
 /* Define the default aerosol and EPS value */
 #define DEFAULT_AERO 0.05


### PR DESCRIPTION
This PR revises the version we'll use for the latest modifications of our NASA-IMPACT fork of the USGS `v3.5.1`. We will be appending a "maintainer version" to the upstream version so we don't override any future release versions (e.g., if USGS publishes a `v3.5.2`) and to indicate that our fork is based on `v3.5.1` release.

As part of this PR I've added a top level `CHANGELOG.md` that loosely follows Semantic Versioning specifications.