### PR TITLE
fix: write Landsat cirrus as TOA reflectance and write outputs with nodata defined

### DIFF
--- a/lasrc_core/src/constants.rs
+++ b/lasrc_core/src/constants.rs
@@ -65,6 +65,11 @@ pub const NREFLL_BANDS: usize = 7;
 pub const NSRL_BANDS: usize = 8;
 pub const NBANDL_THM: usize = 2;
 
+// Landsat output-band index for the cirrus band (B9). Not atmospherically
+// corrected; the TOA reflectance is copied through instead, matching C's
+// SRL_BAND9 handling in lasrc.c.
+pub const SRL_BAND9: usize = 7;
+
 // Reflectance valid range
 pub const MIN_VALID_REFL: f64 = -0.2;
 pub const MAX_VALID_REFL: f64 = 1.60;

--- a/lasrc_core/src/constants.rs
+++ b/lasrc_core/src/constants.rs
@@ -89,6 +89,9 @@ pub const SCALE_FACTOR_AERO: f64 = 0.001;
 pub const MULT_FACTOR_AERO: f64 = 1000.0;
 pub const AERO_FILL: i16 = -9999;
 
+// Fill/nodata value written into output SR and BT bands for fill pixels.
+pub const SR_FILL_VALUE: u16 = 0;
+
 // AOT values at 550nm (22 values)
 pub const AOT550NM: [f64; NAOT_VALS] = [
     0.01, 0.05, 0.10, 0.15, 0.20, 0.30, 0.40, 0.60,

--- a/lasrc_core/src/correction.rs
+++ b/lasrc_core/src/correction.rs
@@ -995,7 +995,7 @@ pub fn compute_surface_reflectance(
             Array2::from_shape_fn((nlines, nsamps), |(i, j)| {
                 let pix = i * nsamps + j;
                 if is_fill_pixel(qa_flat[pix]) {
-                    0u16
+                    SR_FILL_VALUE
                 } else {
                     let sband_f32 = band[pix] as f32;
                     let tmpf = (sband_f32 + offset_f32) * mult_f32;
@@ -1012,7 +1012,7 @@ pub fn compute_surface_reflectance(
             let arr: Array2<u16> = Array2::from_shape_fn((nlines, nsamps), |(i, j)| {
                 let val = bt[(i, j)] as f64;
                 if val < MIN_VALID_TH || val > MAX_VALID_TH {
-                    0u16
+                    SR_FILL_VALUE
                 } else {
                     ((val - BAND_OFFSET_TH) * MULT_FACTOR_TH)
                         .round()
@@ -1659,7 +1659,7 @@ pub fn compute_sentinel_surface_reflectance(
             Array2::from_shape_fn((nlines, nsamps), |(i, j)| {
                 let pix = i * nsamps + j;
                 if is_fill_pixel(qaband[pix]) {
-                    0u16
+                    SR_FILL_VALUE
                 } else {
                     let sband_f32 = band[pix] as f32;
                     let tmpf = (sband_f32 + offset_f32) * mult_f32;

--- a/lasrc_core/src/correction.rs
+++ b/lasrc_core/src/correction.rs
@@ -919,25 +919,33 @@ pub fn compute_surface_reflectance(
                 let eps = teps[pix] as f64;
 
                 for iband in 0..nbands {
-                    // Reconstruct TOA from climatological SR
-                    let rsurf = sband[iband][pix]; // f32
-                    let rotoa: f32 = ((rsurf as f64 * bttatmg[iband]
-                        / (1.0 - bsatm[iband] * rsurf as f64)
-                        + broatm[iband])
-                        * btgo[iband]) as f32;
+                    let roslamb = if iband == SRL_BAND9 {
+                        // Cirrus band: not atmospherically corrected, just
+                        // TOA reflectance normalized by cos(SZA). Matches
+                        // C's SRL_BAND9 handling in lasrc.c.
+                        let xmus = (solar_zenith[(iline, isamp)] as f64 * DEG2RAD).cos();
+                        (toa_bands[iband][(iline, isamp)] as f64 / xmus)
+                            .clamp(MIN_VALID_REFL, MAX_VALID_REFL)
+                    } else {
+                        // Reconstruct TOA from climatological SR
+                        let rsurf = sband[iband][pix]; // f32
+                        let rotoa: f32 = ((rsurf as f64 * bttatmg[iband]
+                            / (1.0 - bsatm[iband] * rsurf as f64)
+                            + broatm[iband])
+                            * btgo[iband]) as f32;
 
-                    let roslamb = atmcorlamb2_new(
-                        &atm_coeff[iband],
-                        tgo_arr[iband],
-                        iband,
-                        raot,
-                        normext_p0a3[iband],
-                        rotoa as f64,
-                        lambda,
-                        eps,
-                    );
-
-                    let roslamb = roslamb.clamp(MIN_VALID_REFL, MAX_VALID_REFL);
+                        atmcorlamb2_new(
+                            &atm_coeff[iband],
+                            tgo_arr[iband],
+                            iband,
+                            raot,
+                            normext_p0a3[iband],
+                            rotoa as f64,
+                            lambda,
+                            eps,
+                        )
+                        .clamp(MIN_VALID_REFL, MAX_VALID_REFL)
+                    };
 
                     // SAFETY: Each iline is processed by exactly one thread
                     // (Rayon's into_par_iter guarantees this). Within a thread,

--- a/lasrc_py/python/lasrc/__init__.py
+++ b/lasrc_py/python/lasrc/__init__.py
@@ -1,4 +1,4 @@
-from lasrc.lasrc import __version__, PyLookupTables, PyAuxiliaryData, process_surface_reflectance, process_sentinel_surface_reflectance
+from lasrc.lasrc import __version__, PyLookupTables, PyAuxiliaryData, process_surface_reflectance, process_sentinel_surface_reflectance, SR_FILL_VALUE
 from lasrc.pipeline import AuxFilePaths
 
 __all__ = [
@@ -7,5 +7,6 @@ __all__ = [
     "PyAuxiliaryData",
     "process_surface_reflectance",
     "process_sentinel_surface_reflectance",
+    "SR_FILL_VALUE",
     "AuxFilePaths",
 ]

--- a/lasrc_py/python/lasrc/io/output.py
+++ b/lasrc_py/python/lasrc/io/output.py
@@ -18,8 +18,10 @@ from pathlib import Path
 import numpy as np
 import rasterio
 
+from lasrc.lasrc import SR_FILL_VALUE
 
-def _write_envi_band(path, data, crs, transform) -> None:
+
+def _write_envi_band(path, data, crs, transform, nodata=None) -> None:
     """Write a single 2-D array as a georeferenced ENVI band (.img + .hdr)."""
     height, width = data.shape
     with rasterio.open(
@@ -32,6 +34,7 @@ def _write_envi_band(path, data, crs, transform) -> None:
         dtype=data.dtype,
         crs=crs,
         transform=transform,
+        nodata=nodata,
     ) as dst:
         dst.write(data, 1)
 
@@ -54,7 +57,8 @@ def write_espa_output(output_dir: str | Path, result: dict,
 
     for i, name in enumerate(sensor_config["refl_band_names"]):
         band = result["sr_bands"][i].astype(np.int16)
-        _write_envi_band(output_dir / f"{prefix}{name}.img", band, crs, transform)
+        _write_envi_band(output_dir / f"{prefix}{name}.img", band, crs, transform,
+                         nodata=SR_FILL_VALUE)
 
     _write_envi_band(output_dir / f"{prefix}sr_aerosol.img",
                      result["aerosol"].astype(np.int16), crs, transform)
@@ -79,6 +83,7 @@ def write_cog_output(output_path: str | Path, result: dict,
         tiled=True,
         blockxsize=512,
         blockysize=512,
+        nodata=SR_FILL_VALUE,
     )
 
     with rasterio.open(output_path, "w", **cog_profile) as dst:

--- a/lasrc_py/src/lib.rs
+++ b/lasrc_py/src/lib.rs
@@ -2,7 +2,7 @@ use numpy::{IntoPyArray, PyArray1, PyReadonlyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use lasrc_core::constants::NSOLAR_ZEN_VALS;
+use lasrc_core::constants::{NSOLAR_ZEN_VALS, SR_FILL_VALUE};
 use lasrc_core::correction::{AuxiliaryData, compute_surface_reflectance, compute_sentinel_surface_reflectance};
 use lasrc_core::geometry::SpaceDef;
 use lasrc_core::lut::LookupTables;
@@ -320,6 +320,7 @@ fn process_sentinel_surface_reflectance<'py>(
 #[pymodule]
 fn lasrc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.1.0")?;
+    m.add("SR_FILL_VALUE", SR_FILL_VALUE)?;
     m.add_class::<PyLookupTables>()?;
     m.add_class::<PyAuxiliaryData>()?;
     m.add_function(wrap_pyfunction!(process_surface_reflectance, m)?)?;


### PR DESCRIPTION
## Description

This PR fixes two issues:

- The Landsat code path ran atmospheric correction on the cirrus band. LaSRC (C version) didn't do this and instead saved it as TOA reflectance, so this change will improve parity while saving us some extra compute. The Sentinel-2 pathway already handled this correctly
- The output files we wrote did not define the "no data value" (`0`)

## How I did it

- Define the Landsat cirrus band as a constant. Switch on the band index and only perform TOA reflectance conversion
- Define the surface reflectance fill value in Rust code. Import this value into the Python bindings. Use this value as "no data value" when writing ENVI or COG formatted outputs