### PR TITLE
fix: residuals accumulation and output data types

### DIFF
--- a/lasrc_core/src/aerosol.rs
+++ b/lasrc_core/src/aerosol.rs
@@ -113,8 +113,11 @@ pub fn subaeroret_new(
                     // C: point_error = roslamb - erelc[ib] * ros1 (double)
                     // roslamb is float promoted to double, erelc[ib] is float promoted to double
                     let point_error: f64 = roslamb as f64 - (erelc[ib] as f32 as f64) * ros1;
-                    // C: *residual += point_error * point_error (float += double)
-                    residual += (point_error * point_error) as f32;
+                    // C: *residual += point_error * point_error  (float += double)
+                    // The accumulation happens in double (float promoted), then
+                    // the sum is rounded back to float -- NOT the term rounded
+                    // first. Match that ordering.
+                    residual = (residual as f64 + point_error * point_error) as f32;
                     nbval += 1;
                 }
             }

--- a/lasrc_py/python/lasrc/__init__.py
+++ b/lasrc_py/python/lasrc/__init__.py
@@ -1,4 +1,4 @@
-from lasrc.lasrc import __version__, PyLookupTables, PyAuxiliaryData, process_surface_reflectance, process_sentinel_surface_reflectance, SR_FILL_VALUE
+from lasrc.lasrc import __version__, PyLookupTables, PyAuxiliaryData, process_surface_reflectance, process_sentinel_surface_reflectance, SR_FILL_VALUE, AERO_FILL
 from lasrc.pipeline import AuxFilePaths
 
 __all__ = [
@@ -8,5 +8,6 @@ __all__ = [
     "process_surface_reflectance",
     "process_sentinel_surface_reflectance",
     "SR_FILL_VALUE",
+    "AERO_FILL",
     "AuxFilePaths",
 ]

--- a/lasrc_py/python/lasrc/io/output.py
+++ b/lasrc_py/python/lasrc/io/output.py
@@ -9,8 +9,9 @@ Three formats are supported, all driven by the same in-memory ``result`` dict
   - NumPy raw            : headerless flat binary ``.img`` files (``ndarray.tofile``),
     kept only for compatibility with the analysis/test scripts.
 
-Output dtypes follow the ESPA convention: surface reflectance and aerosol are
-int16, the aerosol QA band is uint8.
+Output dtypes match the C reference exactly: surface reflectance (and
+brightness temperature) bands are uint16, the aerosol band is int16, and the
+aerosol QA band is uint8.
 """
 
 from pathlib import Path
@@ -18,16 +19,16 @@ from pathlib import Path
 import numpy as np
 import rasterio
 
-from lasrc.lasrc import SR_FILL_VALUE
+from lasrc.lasrc import AERO_FILL, SR_FILL_VALUE
 
 
-def _write_envi_band(path, data, crs, transform, nodata=None) -> None:
-    """Write a single 2-D array as a georeferenced ENVI band (.img + .hdr)."""
+def _write_band(path, data, crs, transform, driver, nodata=None, **creation_opts) -> None:
+    """Write a single 2-D array as a georeferenced raster band."""
     height, width = data.shape
     with rasterio.open(
         path,
         "w",
-        driver="ENVI",
+        driver=driver,
         width=width,
         height=height,
         count=1,
@@ -35,6 +36,7 @@ def _write_envi_band(path, data, crs, transform, nodata=None) -> None:
         crs=crs,
         transform=transform,
         nodata=nodata,
+        **creation_opts,
     ) as dst:
         dst.write(data, 1)
 
@@ -56,44 +58,45 @@ def write_espa_output(output_dir: str | Path, result: dict,
     prefix = f"{product_id}_" if product_id else ""
 
     for i, name in enumerate(sensor_config["refl_band_names"]):
-        band = result["sr_bands"][i].astype(np.int16)
-        _write_envi_band(output_dir / f"{prefix}{name}.img", band, crs, transform,
-                         nodata=SR_FILL_VALUE)
+        band = result["sr_bands"][i].astype(np.uint16)
+        _write_band(output_dir / f"{prefix}{name}.img", band, crs, transform,
+                    driver="ENVI", nodata=SR_FILL_VALUE)
 
-    _write_envi_band(output_dir / f"{prefix}sr_aerosol.img",
-                     result["aerosol"].astype(np.int16), crs, transform)
-    _write_envi_band(output_dir / f"{prefix}sr_aerosol_qa.img",
-                     result["qa"].astype(np.uint8), crs, transform)
+    _write_band(output_dir / f"{prefix}sr_aerosol.img",
+               result["aerosol"].astype(np.int16), crs, transform,
+               driver="ENVI", nodata=AERO_FILL)
+    _write_band(output_dir / f"{prefix}sr_aerosol_qa.img",
+               result["qa"].astype(np.uint8), crs, transform,
+               driver="ENVI")
 
 
-def write_cog_output(output_path: str | Path, result: dict,
-                     sensor_config: dict, profile: dict) -> None:
-    """Write output as a single multi-band Cloud-Optimized GeoTIFF."""
-    output_path = Path(output_path)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+_COG_CREATION_OPTS = dict(compress="deflate", tiled=True, blockxsize=512, blockysize=512)
 
-    nbands = len(result["sr_bands"])
 
-    cog_profile = profile.copy()
-    cog_profile.update(
-        driver="GTiff",
-        dtype="int16",
-        count=nbands + 2,
-        compress="deflate",
-        tiled=True,
-        blockxsize=512,
-        blockysize=512,
-        nodata=SR_FILL_VALUE,
-    )
+def write_cog_output(output_dir: str | Path, result: dict,
+                     sensor_config: dict, crs, transform,
+                     product_id: str = "") -> None:
+    """Write output as one Cloud-Optimized GeoTIFF per band.
 
-    with rasterio.open(output_path, "w", **cog_profile) as dst:
-        for i, band in enumerate(result["sr_bands"]):
-            dst.write(band.astype(np.int16), i + 1)
-            dst.set_band_description(i + 1, sensor_config["refl_band_names"][i])
-        dst.write(result["aerosol"].astype(np.int16), nbands + 1)
-        dst.set_band_description(nbands + 1, "sr_aerosol")
-        dst.write(result["qa"].astype(np.uint8), nbands + 2)
-        dst.set_band_description(nbands + 2, "sr_aerosol_qa")
+    Mirrors write_espa_output's one-file-per-band layout (and the C
+    reference's per-band native dtypes: uint16 SR/BT, int16 aerosol, uint8
+    QA), just using the GTiff/COG driver instead of ENVI.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"{product_id}_" if product_id else ""
+
+    for i, name in enumerate(sensor_config["refl_band_names"]):
+        band = result["sr_bands"][i].astype(np.uint16)
+        _write_band(output_dir / f"{prefix}{name}.tif", band, crs, transform,
+                    driver="GTiff", nodata=SR_FILL_VALUE, **_COG_CREATION_OPTS)
+
+    _write_band(output_dir / f"{prefix}sr_aerosol.tif",
+               result["aerosol"].astype(np.int16), crs, transform,
+               driver="GTiff", nodata=AERO_FILL, **_COG_CREATION_OPTS)
+    _write_band(output_dir / f"{prefix}sr_aerosol_qa.tif",
+               result["qa"].astype(np.uint8), crs, transform,
+               driver="GTiff", **_COG_CREATION_OPTS)
 
 
 def write_numpy(output_dir: str | Path, result: dict,
@@ -104,7 +107,7 @@ def write_numpy(output_dir: str | Path, result: dict,
     prefix = f"{product_id}_" if product_id else ""
 
     for i, name in enumerate(sensor_config["refl_band_names"]):
-        result["sr_bands"][i].astype(np.int16).tofile(output_dir / f"{prefix}{name}.bin")
+        result["sr_bands"][i].astype(np.uint16).tofile(output_dir / f"{prefix}{name}.bin")
 
     result["aerosol"].astype(np.int16).tofile(output_dir / f"{prefix}sr_aerosol.bin")
     result["qa"].astype(np.uint8).tofile(output_dir / f"{prefix}sr_aerosol_qa.bin")

--- a/lasrc_py/python/lasrc/pipeline.py
+++ b/lasrc_py/python/lasrc/pipeline.py
@@ -135,6 +135,8 @@ def process_scene(
     elif output_format == "numpy":
         write_numpy(output_path, result, sensor_config, product_id=product_id)
     else:
-        write_cog_output(output_path, result, sensor_config, profile)
+        write_cog_output(output_path, result, sensor_config,
+                         crs=profile["crs"], transform=transform,
+                         product_id=product_id)
 
     return result

--- a/lasrc_py/src/lib.rs
+++ b/lasrc_py/src/lib.rs
@@ -2,7 +2,7 @@ use numpy::{IntoPyArray, PyArray1, PyReadonlyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use lasrc_core::constants::{NSOLAR_ZEN_VALS, SR_FILL_VALUE};
+use lasrc_core::constants::{AERO_FILL, NSOLAR_ZEN_VALS, SR_FILL_VALUE};
 use lasrc_core::correction::{AuxiliaryData, compute_surface_reflectance, compute_sentinel_surface_reflectance};
 use lasrc_core::geometry::SpaceDef;
 use lasrc_core::lut::LookupTables;
@@ -321,6 +321,7 @@ fn process_sentinel_surface_reflectance<'py>(
 fn lasrc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.1.0")?;
     m.add("SR_FILL_VALUE", SR_FILL_VALUE)?;
+    m.add("AERO_FILL", AERO_FILL)?;
     m.add_class::<PyLookupTables>()?;
     m.add_class::<PyAuxiliaryData>()?;
     m.add_function(wrap_pyfunction!(process_surface_reflectance, m)?)?;


### PR DESCRIPTION
## Description

This PR fixes two issues I found in the Rust/Python port:

1. There is a very tiny discrepancy between the Rust and C version in the `subaeronet_new` function due to the data type used for accumulating the residuals as already noted in the documentation.
    - The C version adds a `double` to a `float` in place (`+=`), which first upcasts the `float` to a `double` and then downcasts after the summation
2. We observed large differences in the C versus Rust/Python outputs over bright targets where the Rust/Python outputs had negative values. This was the result of the Python code writing very large integers into an Int16, which caused a wraparound
    - The fix for this is to output each band as a separate file (ENVI/GeoTIFF/NumPy binary) so we can use a suitable dtype and fill value. I used the dtypes from the C code (SR bands as `uint16`, Aerosol band as `int16`, and Aerosol QA as `byte`)
    - I exported the Aerosol fill value from the Rust code into the Python wrapper so we can use that as a single-source-of-truth for the output file format fill value